### PR TITLE
Revert "Bump ua-parser-js from 0.7.23 to 0.7.28"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11259,9 +11259,9 @@
             "dev": true
         },
         "ua-parser-js": {
-            "version": "0.7.28",
-            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-            "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+            "version": "0.7.23",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+            "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
             "dev": true
         },
         "uglify-js": {


### PR DESCRIPTION
Reverts RicBM71/gestoro#17